### PR TITLE
Added default fallback for unmapped virtual hosts

### DIFF
--- a/default/README.md
+++ b/default/README.md
@@ -1,0 +1,3 @@
+# Sokka default page
+
+This directory contains a simple static HTML page used as a fallback site for unmapped virtual hosts in the Docker nginx reverse proxy.

--- a/default/assets/style.css
+++ b/default/assets/style.css
@@ -1,0 +1,30 @@
+body {
+  margin: 0;
+  padding: 0;
+}
+
+.vertical-center {
+  min-height: 100%;
+  min-height: 100vh;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  background-color: #ffffff;
+}
+
+.vertical-center .container {
+  text-align: center;
+}
+
+.vertical-center .container h1 {
+  margin: 0;
+}
+
+.vertical-center .container p {
+  padding: 16px 0;
+  margin: 0;
+}
+
+.text-muted {
+  font-size: 10pt;
+}

--- a/default/index.html
+++ b/default/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <!-- Bootstrap -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css"
+        integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous" />
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="assets/style.css" />
+
+    <title>404 — Sokka</title>
+</head>
+
+<body>
+    <div class="jumbotron vertical-center">
+        <div class="container">
+            <h1>Big oof</h1>
+            <p>Seems like you have reached a dead end. Sorry!</p>
+            <div class="footer">
+                <span class="text-muted">Copyright © <span id="year"></span> <a href="https://sokka.me/">Sokka Project</a></span>
+            </div>
+        </div>
+    </div>
+    <script>
+        document.getElementById('year').innerHTML = new Date().getFullYear();
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
In case the nginx reverse proxy is accessed through an unmapped virtual host or cannot find the host mapped (i. e. if the designated container is down), the nginx reverse proxy is configured to fall back to this static 404 page.

We might end up implementing this differently later because we will also need a 404 page for the ACP and Flutter web app.